### PR TITLE
Added license information

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -8,6 +8,7 @@
         <platform>all</platform>
         <language/>
         <website></website>
+        <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
         <source>https://github.com/dersphere/script.screensaver.nyancat</source>
         <forum>http://forum.xbmc.org/showthread.php?tid=168442</forum>
         <email>sphere@dersphere.de</email>


### PR DESCRIPTION
Needed to automatically fill the links on http://kodi.wiki and http://addons.kodi.tv/ sites.
