### PR TITLE
"largeimage" controls have been removed in Krypton

### DIFF
--- a/resources/skins/default/720p/script-Nyancat-main.xml
+++ b/resources/skins/default/720p/script-Nyancat-main.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <window type="window">
     <controls>
         <control type="label" id="1">
@@ -8,7 +8,7 @@
             <width>0</width>
             <height>0</height>
         </control>
-        <control type="largeimage">
+        <control type="image">
             <description>Background Image</description>
             <posx>0</posx>
             <posy>0</posy>
@@ -17,7 +17,7 @@
             <texture>background.jpg</texture>
             <animation effect="slide" start="0,0" end="-1280,0" center="auto" time="3000" loop="true" condition="!Control.IsVisible(1)">conditional</animation>
         </control>
-        <control type="largeimage">
+        <control type="image">
             <description>Background Image 2</description>
             <posx>0</posx>
             <posy>0</posy>


### PR DESCRIPTION
"largeimage" controls have been removed as of
https://github.com/xbmc/xbmc/commit/70d975287033981ff3f10021b6a2191e4d6939ba.

Use the "image" control for background instead. This fixes the missing
starry background on Kodi Krypton.